### PR TITLE
Add CTC library to CMakeLists

### DIFF
--- a/src/criterion/CMakeLists.txt
+++ b/src/criterion/CMakeLists.txt
@@ -29,6 +29,8 @@ if (FLASHLIGHT_USE_CUDA)
     INTERFACE
     ${CUDA_LIBRARIES}
     warpctc # added directly from subdir
+    # Can remove once CTC constrained Viterbi is implemented in CUDA T62268085
+    criterion-library
     )
 
   target_include_directories(

--- a/src/libraries/criterion/CMakeLists.txt
+++ b/src/libraries/criterion/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(
   INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu/CriterionUtils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu/ForceAlignmentCriterion.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cpu/ConnectionistTemporalClassificationCriterion.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu/FullConnectionCriterion.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpu/ViterbiPath.cpp
   )


### PR DESCRIPTION
Summary: Add CTC library to CMakeList to fix broken build in https://circleci.com/gh/facebookresearch/wav2letter/397

Reviewed By: avidov, tlikhomanenko

Differential Revision: D19910254

fbshipit-source-id: b88df4430f85fca59ad443c5897818f8e9b9c3bf